### PR TITLE
python3.2 thread compatibility for RPis

### DIFF
--- a/bucket.py
+++ b/bucket.py
@@ -177,4 +177,4 @@ if __name__ == "__main__":
 
 
     while True:
-        Bucket(myVersion) 
+        Bucket(myVersion)

--- a/fountain.py
+++ b/fountain.py
@@ -79,7 +79,8 @@ def checkConsistency(theirVersion, VERSION, founTT):
         logger.info("They are behind.. Starting Fountain")
         if founTT.can_transmit():
             global threadFount
-            threadFount = threading.Thread(target=fountain, args=(gv.FILENAME, gv.BLOCKSIZE, VERSION), daemon=True)
+            threadFount = threading.Thread(target=fountain, args=(gv.FILENAME, gv.BLOCKSIZE, VERSION))
+            threadFount.daemon = True
             threadFount.start()
             threadFount.join()
         founTT.hear_inconsistent()


### PR DESCRIPTION
`daemon` on **python3.2** not an argument but as a statement. Back porting issue solved on RPi2 with this one!
