### PR TITLE
Routing Table in JSON:v0.2

### DIFF
--- a/TWIN/bucket.py
+++ b/TWIN/bucket.py
@@ -5,6 +5,7 @@ from io import BytesIO
 from struct import pack, unpack
 from TWIN.fountain import CheckConsistency
 from os import chdir, path
+from TWIN.route import addRoute
 import sys, socket
 import logging
 
@@ -90,6 +91,8 @@ def bucket():
                 ## - this is trickleMessage
                 theirVersion = unpack('!H', data)[0]
                 logger.info("Version Check for %s"%recvAddr)
+                ## store the IP address of Trickle Neighbor
+                addRoute(foun=None, neigh=recvAddr)
 
                 CheckConsistency(theirVersion)
 
@@ -139,6 +142,8 @@ def bucket():
                         ## Global Filename variable
                         gv.FILENAME = open_next_file(decoder)
                         logger.debug("Total Droplets Received:%d"%receivedDroplets)
+                        ## Store the Fountain address in routeTable.json
+                        addRoute(foun=recvAddr, neigh=None)
                         break
 
     except socket.error as sockErr:

--- a/TWIN/global_variables.py
+++ b/TWIN/global_variables.py
@@ -35,3 +35,7 @@ FILENAME = "trialPack.tar"
 ## Path Variable for the Filename
 
 PATH = "/home/testbed/hexfiles"
+
+## Dictionary Cache for a pseudo-route table
+
+rCache = {'fountain': '', 'neighbors':[]}

--- a/TWIN/route.py
+++ b/TWIN/route.py
@@ -1,0 +1,51 @@
+#!/usr/bin/python3
+
+#	Routing table Entry function
+#	add a fountain IPv6 address or Neighbor
+#	IPv6 address to global variable `rCache`
+
+from os import chdir, path
+import json
+from TWIN.global_variables import rCache
+
+def addRoute(foun=None, neigh=None):
+    """
+        Function: addRoute
+        param: one fountain address, neighboring node address
+        defaults: None (for both params)
+
+        Description:
+        a function to add IPv6 address of either Fountain or 
+        nearby neighbors and store the content into JSON format
+        for future access over REST.
+    """
+
+    if foun is None or foun == "":
+        ## don't add anything if field
+        ## empty
+        pass
+
+    else:
+        ## if parameter exists
+        ## update the Dictionary
+        rCache['fountain'] = foun
+
+    if neigh is None or neigh == "":
+        ## don't append entry to list
+        ## if parameter is empty/None
+        pass
+
+    else:
+        if neigh in rCache['neighbors']:
+            ## if the IPv6 address already
+            ## exists don't append it..
+            pass
+
+        else:
+            rCache['neighbors'].append(neigh)
+
+    # Save in /home/ folder
+    chdir(path.expanduser("~"))
+
+    with open("routeTable.json", 'w+') as rtable:
+        json.dump(rCache, rtable)


### PR DESCRIPTION
This PR targets #13 where storing Incoming IPv6 LL addresses was of a question. Data now get's stored in JSON keeping in mind the usage with REST Resource in the future.

This will also be used to set the Retrieval of data.
BUMP from v0.1.1 -> v0.2
