### PR TITLE
Adding Path Variable for incoming/outgoing data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,5 @@ target/
 #Log files
 log/
 *.log
+*.json
+transmissions/

--- a/README.md
+++ b/README.md
@@ -16,35 +16,53 @@ It uses:
 __Case__:
 
 
-    python3 Sprinkler.py --version 1 --filename /path/to/file --group ff32::2
+    python3 Sprinkler.py
+    --version 1 --path /path/to/dir/
+    --filename file_to_send --group ff32::2
     --port 30002
 
-will distribute the file `/path/to/file` over the wireless ad-hoc network Nodes
-which are running the same code but will lower `version` number (for instance __0__)
+will distribute the file `/path/to/dir/file_to_send` over the wireless ad-hoc network Nodes
+which are running the same code but will lower `version` number (for instance __0__).
+ The `/path/to/dir` will also store all new incoming files.
 
 General:
+```
+usage: Sprinkler.py [-h] [-V VERSION] [-b BLOCK] [-pt PATH] [-f FILENAME]
+                [-g GROUP] [-p PORT]
 
-    usage: Sprinkler.py [-h] [-V VERSION] [-b BLOCK] [-f FILENAME] [-g GROUP]
-                    [-p PORT]
+Sprinkler Wireless Data Dissemination Protocol
 
-    Sprinkler Wireless Data Dissemination Protocol
+optional arguments:
+-h, --help            show this help message and exit
+-V VERSION, --version VERSION
+                    Version Number for Updated Data
+-b BLOCK, --block BLOCK
+                    Encoding Block Length, keep it less than 1500B
+-pt PATH, --path PATH
+                    Path to the file for Dissemination / storing Incoming
+                    file over channel. Default is
+                    current_folder/transmissions
+-f FILENAME, --filename FILENAME
+                    Main File for Fountain. provide complete path
+-g GROUP, --group GROUP
+                    IPv6 Multicast Group. Default is ff02::1
+-p PORT, --port PORT  port number. Default is 30001
 
-    optional arguments:
-    -h, --help            show this help message and exit
-    -V VERSION, --version VERSION
-                        Version Number for Updated Data
-    -b BLOCK, --block BLOCK
-                        Encoding Block Length, keep it less than 1500B
-    -f FILENAME, --filename FILENAME
-                        Main File for Fountain. provide complete path
-    -g GROUP, --group GROUP
-                        IPv6 Multicast Group. Default is ff02::1
-    -p PORT, --port PORT  port number. Default is 30001
-
+```
 
 ### Setup
 
     sudo ./setup.sh
+
+This file will:
+
+* Check for `python3` and `pip3`
+
+* install the `lt-code` pip module
+
+* make necessary folders for the API and relevant dummy files for default operation
+
+* creates `routeTable.json` for storing information of nearby neighbors and source of information `fountain`
 
 ## Application
 

--- a/Sprinkler/global_variables.py
+++ b/Sprinkler/global_variables.py
@@ -56,7 +56,7 @@ PATH = path.expanduser(".") + "/transmissions"
 
 # Filename for Encoding
 
-FILENAME = PATH + "/dummy.bin"
+FILENAME = "dummy.bin"
 
 # Dictionary Cache for a pseudo-route table
 

--- a/Sprinkler/global_variables.py
+++ b/Sprinkler/global_variables.py
@@ -23,6 +23,7 @@ __author__ = "Shantanoo Desai"
 """
     Global Variables Used Through Out the Module
 """
+from os import path
 
 # Version for Trickle Algorithm
 VERSION = 0
@@ -50,9 +51,12 @@ MCAST_TTL = 2
 
 BLOCKSIZE = 1450
 
+# Path for Incoming/Outgoing Folder
+PATH = path.expanduser(".") + "/transmissions"
+
 # Filename for Encoding
 
-FILENAME = "./log/dummy.bin"
+FILENAME = PATH + "/dummy.bin"
 
 # Dictionary Cache for a pseudo-route table
 

--- a/Sprinkler/main.py
+++ b/Sprinkler/main.py
@@ -53,6 +53,11 @@ def main(args):
     parser.add_argument("-b", "--block", type=int, default=gv.BLOCKSIZE,
                         help="Encoding Block Length, keep it less than 1500B")
 
+    parser.add_argument("-pt", "--path", type=str, default=gv.PATH,
+                        help="Path to the file for Dissemination / storing\
+                         Incoming file over channel.\
+                         Default is current_folder/transmissions")
+
     parser.add_argument("-f", "--filename", type=str, default=gv.FILENAME,
                         help="Main File for Fountain. provide complete path")
 
@@ -68,7 +73,13 @@ def main(args):
 
     gv.BLOCKSIZE = args.block
 
+    gv.PATH = args.path
+
     gv.FILENAME = args.filename
+
+    if not path.exists(gv.PATH):
+        print("Specified does not exist. use --pt to add path.")
+        sys.exit(1)
 
     if gv.FILENAME is None or gv.FILENAME == "":
         print("No File Mentioned. use --filename to add a file")

--- a/Sprinkler/main.py
+++ b/Sprinkler/main.py
@@ -27,7 +27,7 @@ from Sprinkler.Socket import Socket
 from Sprinkler.trickle import trickleTimer
 from struct import pack
 from Sprinkler.bucket import bucket
-from os import path
+from os import path, chdir
 import logging
 
 # Central Logging Entity
@@ -78,19 +78,20 @@ def main(args):
     gv.FILENAME = args.filename
 
     if not path.exists(gv.PATH):
-        print("Specified does not exist. use --pt to add path.")
+        print("Specified does not exist. use --path or -pt to add path.")
         sys.exit(1)
 
     if gv.FILENAME is None or gv.FILENAME == "":
-        print("No File Mentioned. use --filename to add a file")
+        print("No File Mentioned. use --filename or -f to add a file")
         sys.exit(1)
 
     gv.MCAST_GRP = args.group
 
     gv.MCAST_PORT = args.port
 
+    chdir(gv.PATH)
     if not path.exists(gv.FILENAME):
-        print("File or path Does not Exist")
+        print("File Does not Exist..")
         sys.exit(1)
 
     logger.debug("Starting with Version %d" % gv.VERSION)

--- a/setup.sh
+++ b/setup.sh
@@ -37,15 +37,16 @@ echo "SETUP: generating log folder in current directory"
 echo
 
 mkdir $DESTDIR/log
+mkdir $DESTDIR/transmissions
 
 # make dummy file for receiving Nodes
 # make the argument parser point to this dummy file by default
 
-touch $DESTDIR/log/dummy.bin
+touch $DESTDIR/transmissions/dummy.bin
 touch $DESTDIR/routeTable.json
 
 # Change ownership (not root!)
-chown -R $CURRENT_USER:$CURRENT_USER $DESTDIR/log $DESTDIR/routeTable.json
+chown -R $CURRENT_USER:$CURRENT_USER $DESTDIR/log $DESTDIR/routeTable.json $DESTDIR/transmissions
 
 echo
 echo "SETUP complete."


### PR DESCRIPTION
This is in response to #23 . This is necessary since no folder specification would crash the API.

* added a default `transmission/` folder for dummy operations

* resolve the default and specific API error for filename and path variables

* tested on Raspberry Pi platform :+1: 